### PR TITLE
修复/死亡之后飞机残留并且重新开始无法控制的BUG，依赖 PR (fix/player_display_bug)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -512,7 +512,23 @@ fn check_collisions(
 }
 
 // Game over screen setup
-fn setup_game_over(mut commands: Commands, game_data: Res<GameData>) {
+fn setup_game_over(mut commands: Commands, game_data: Res<GameData>, player_query: Query<Entity, With<Player>>, bullet_query: Query<Entity, With<Bullet>>) {
+    // 移除玩家实体
+    match player_query.get_single() {
+        Ok(player_entity) => {
+            commands.entity(player_entity).despawn_recursive();
+            info!("玩家实体已成功移除: {:?}", player_entity);
+        }
+        Err(e) => {
+            warn!("未能找到玩家实体: {:?}", e);
+        }
+    }
+
+    // 移除子弹实体
+    for bullet_entity in bullet_query.iter() {
+        commands.entity(bullet_entity).despawn();
+    }
+
     commands
         .spawn(NodeBundle {
             style: Style {

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,8 +98,11 @@ fn main() {
 
 // Initial setup
 fn setup(mut commands: Commands) {
-    // Add camera
-    commands.spawn((Camera2dBundle::default(), MainCamera));
+    // 设置相机位置在窗口中心
+    commands.spawn((Camera2dBundle {
+        transform: Transform::from_translation(Vec3::new(WINDOW_WIDTH / 2.0, WINDOW_HEIGHT / 2.0, 999.9)),
+        ..default()
+    }, MainCamera));
 }
 
 // Menu screen setup
@@ -210,10 +213,11 @@ fn start_game(
             material: materials.add(ColorMaterial::from(Color::CYAN)),
             transform: Transform::from_translation(Vec3::new(
                 WINDOW_WIDTH / 2.0,
-                WINDOW_HEIGHT * 0.8,
-                0.0,
+                WINDOW_HEIGHT * 0.2,
+                10.0,
             ))
-            .with_rotation(Quat::from_rotation_z(std::f32::consts::PI)),
+            .with_scale(Vec3::splat(1.5))
+            .with_rotation(Quat::from_rotation_z(0.0)),
             ..default()
         },
         Player {


### PR DESCRIPTION
**这个PR依赖fix/player_display_bug，可以按顺序pull。**

游戏结束的时候没有删除玩家实体，导致点了Play Again之后会出现两个Player。

在setup_game_over中增加了删除玩家实体和清空当前弹道的代码。